### PR TITLE
Introduced build.args file containing DOCKER_REPO variable

### DIFF
--- a/add-on/multi-instance-skeleton/actions/multipurposeaction/Dockerfile
+++ b/add-on/multi-instance-skeleton/actions/multipurposeaction/Dockerfile
@@ -2,13 +2,11 @@
 # Copyright 2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 # ------------------------------------------------------
-
-# syntax=docker/dockerfile:1
-
-# ------------------------------------------------------
 # Build element
 # ------------------------------------------------------
-FROM golang:1.19.2-bullseye AS GOLANG
+ARG DOCKER_REPO
+
+FROM $DOCKER_REPO/golang:1.19.2-bullseye AS GOLANG
 
 ADD . /opt/src
 WORKDIR /opt/src

--- a/add-on/multi-instance-skeleton/actions/multipurposeaction/build.args
+++ b/add-on/multi-instance-skeleton/actions/multipurposeaction/build.args
@@ -1,0 +1,1 @@
+DOCKER_REPO=docker.io

--- a/add-on/multi-instance-skeleton/backend-appliance/Dockerfile
+++ b/add-on/multi-instance-skeleton/backend-appliance/Dockerfile
@@ -2,10 +2,6 @@
 # Copyright 2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 # ------------------------------------------------------
-
-# syntax=docker/dockerfile:1
-
-# ------------------------------------------------------
 # Output element artifacts
 # ------------------------------------------------------
 FROM scratch AS export

--- a/add-on/multi-instance-skeleton/db-schemas/Dockerfile
+++ b/add-on/multi-instance-skeleton/db-schemas/Dockerfile
@@ -2,13 +2,11 @@
 # Copyright 2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 # ------------------------------------------------------
-
-# syntax=docker/dockerfile:1
-
-# ------------------------------------------------------
 # Build element
 # ------------------------------------------------------
-FROM node:16-slim as build
+ARG DOCKER_REPO
+
+FROM $DOCKER_REPO/node:16-slim as NODE
 WORKDIR /usr/app
 ADD . .
 RUN npm ci && npm run build
@@ -17,4 +15,4 @@ RUN npm ci && npm run build
 # Output element artifacts
 # ------------------------------------------------------
 FROM scratch AS export
-COPY --from=build /usr/app/lib ./
+COPY --from=NODE /usr/app/lib ./

--- a/add-on/multi-instance-skeleton/db-schemas/build.args
+++ b/add-on/multi-instance-skeleton/db-schemas/build.args
@@ -1,0 +1,1 @@
+DOCKER_REPO=docker.io

--- a/add-on/multi-instance-skeleton/ui/Dockerfile
+++ b/add-on/multi-instance-skeleton/ui/Dockerfile
@@ -2,13 +2,10 @@
 # Copyright 2023 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 # ------------------------------------------------------
-
-# syntax=docker/dockerfile:1
-
-# ------------------------------------------------------
 # Build element
 # ------------------------------------------------------
-FROM node:14.20.0-slim as NODE
+ARG DOCKER_REPO
+FROM $DOCKER_REPO/node:14.20.1-slim as NODE
 COPY . /usr/app
 WORKDIR /usr/app
 RUN npm ci

--- a/add-on/multi-instance-skeleton/ui/build.args
+++ b/add-on/multi-instance-skeleton/ui/build.args
@@ -1,0 +1,1 @@
+DOCKER_REPO=docker.io


### PR DESCRIPTION
Introduced build.args file containing DOCKER_REPO variable, used to determine which repository is going to be used for docker images defined in each element Dockerfile. The default is set to DOCKER_REPO=docker.io